### PR TITLE
Add gilab ci pipeline, publish library when a tag is pushed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,34 @@
+# Include Global Configurations
+include:
+  - project: 'api-server/gitlab-ci-scripts'
+    ref: v1.1
+    file: '.global-configuration.yml'
+
+image: code.route360.net:4567/docker/general-image/service/psql9.6:0.0.4
+
+stages:
+  - build
+  - deploy
+
+build:
+   stage: build
+   script:
+     - configure_sonar_scanner
+     - configure_python3_virtual_env
+     - python3 -m compileall -f targomo_python deploy.py setup.py
+     - sonarscanner -Dsonar.sources=targomo_python
+   only:
+     - /^feature.*$/
+     - /^release.*$/
+     - develop
+     - master
+
+deploy:
+   stage: deploy
+   script:
+     - configure_python3_virtual_env
+     - insert_pypirc
+     - echo $CI_COMMIT_TAG
+     - python3 deploy.py --version $CI_COMMIT_TAG
+   only:
+     - tags

--- a/deploy.py
+++ b/deploy.py
@@ -1,24 +1,20 @@
 ### publish new version of this library to PyPI
 
-import git
 from shutil import copyfile
 import fileinput
 import sys
 import os
+import argparse
 
+parser = argparse.ArgumentParser(description="Publish the Targomo python library to PyPi")
+parser.add_argument("--version", required=True, type=str, help="The version number", nargs="?")
+args = parser.parse_args()
 
 copyfile("./setup.py.default", "./setup.py")
 
-repo    = git.Repo(".")
-lasttag = sorted(repo.tags, key=lambda t: t.commit.committed_date)[-1]
-nexttag = "0." + str(int(str(lasttag).replace("0.", "")) + 1)
-
 for line in fileinput.input("./setup.py", inplace=True):
-    line = line.replace("$VERSION", str(nexttag))
+    line = line.replace("$VERSION", args.version)
     sys.stdout.write(line),
-
-new_tag = repo.create_tag(str(nexttag), message='Automatic deployment of new version "{0}"'.format(nexttag))
-repo.remotes.origin.push(new_tag)
 
 os.system("python3 setup.py sdist")
 os.system("twine upload --repository pypitest dist/*")


### PR DESCRIPTION
The lib is published automatically when a tag is pushed. The tag is used as version.

GitLab issue: https://code.route360.net/api-server/wiki/issues/348